### PR TITLE
ci: fix current repository configuration issues

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -107,6 +107,9 @@ orgs.newOrg('eclipse-kura') {
           deployment_branch_policy: "selected",
         },
       ],
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
     },
     orgs.newRepo('kura-apps') {
       allow_merge_commit: true,

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -21,12 +21,7 @@ orgs.newOrg('eclipse-kura') {
   _repositories+:: [
     orgs.newRepo('kura') {
       allow_rebase_merge: false,
-      code_scanning_default_languages+: [
-        "javascript",
-        "javascript-typescript",
-        "python",
-        "typescript"
-      ],
+      code_scanning_default_languages+: [],
       code_scanning_default_setup_enabled: true,
       default_branch: "develop",
       delete_branch_on_merge: false,

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -106,9 +106,6 @@ orgs.newOrg('eclipse-kura') {
           deployment_branch_policy: "selected",
         },
       ],
-      workflows+: {
-        default_workflow_permissions: "write",
-      },
     },
     orgs.newRepo('kura-apps') {
       allow_merge_commit: true,

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -21,8 +21,7 @@ orgs.newOrg('eclipse-kura') {
   _repositories+:: [
     orgs.newRepo('kura') {
       allow_rebase_merge: false,
-      code_scanning_default_languages+: [],
-      code_scanning_default_setup_enabled: true,
+      code_scanning_default_setup_enabled: false,
       default_branch: "develop",
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,


### PR DESCRIPTION
This PR tries to address the two main issues we're currently experiencing:
1. Github actions don't have the permissions to open PRs in the main repo. This renders the backport, deploy-docs and release workflows useless.
2. Deactivates the code scanning features for the lenguages we're not currently actively using in the project (javascript, python).
