### PR TITLE
ci: temporarily disable required Jenkins status check on PRs

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -97,7 +97,7 @@ orgs.newOrg('eclipse-kura') {
         customBranchProtectionRule('develop') {
           required_status_checks+: [
               "Validate PR title",
-              "any:continuous-integration/jenkins/pr-merge",
+              // "any:continuous-integration/jenkins/pr-merge",
           ],
         },
         customBranchProtectionRule('docs-develop') {
@@ -108,7 +108,7 @@ orgs.newOrg('eclipse-kura') {
         customBranchProtectionRule('release-*') {
           required_status_checks+: [
               "Validate PR title",
-              "any:continuous-integration/jenkins/pr-merge",
+              // "any:continuous-integration/jenkins/pr-merge",
           ],
         },
         customBranchProtectionRule('docs-release-*') {


### PR DESCRIPTION
Due to timing constraints we're temporarily disabling the required status check for the Jenkins pipeline.

We plan to re-enable it when we'll implement the solution described in [this comment](https://github.com/eclipse-kura/.eclipsefdn/pull/8#issuecomment-2385116434)