### PR TITLE
ci: temporarily disable required Lint PR status check

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -96,24 +96,24 @@ orgs.newOrg('eclipse-kura') {
       branch_protection_rules: [
         customBranchProtectionRule('develop') {
           required_status_checks+: [
-              "Validate PR title",
+              // "Validate PR title",
               // "any:continuous-integration/jenkins/pr-merge",
           ],
         },
         customBranchProtectionRule('docs-develop') {
           required_status_checks+: [
-              "Validate PR title",
+              // "Validate PR title",
           ]
         },
         customBranchProtectionRule('release-*') {
           required_status_checks+: [
-              "Validate PR title",
+              // "Validate PR title",
               // "any:continuous-integration/jenkins/pr-merge",
           ],
         },
         customBranchProtectionRule('docs-release-*') {
           required_status_checks+: [
-              "Validate PR title",
+              // "Validate PR title",
           ]
         },
       ],


### PR DESCRIPTION
Due to the fact that Github doesn't support triggering workflows from pull requests opened by other workflows we're currently stuck from being able to merge Backports PRs.

We don't have the time to deal with this ATM and thus temporarily disabling it.

We plan to follow the recommended guidelines as soon as we have the time to do so. See:
- https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow