### PR TITLE
ci: restore "Validate PR title" required status check

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -101,24 +101,24 @@ orgs.newOrg('eclipse-kura') {
       branch_protection_rules: [
         customBranchProtectionRule('develop') {
           required_status_checks+: [
-              // "Validate PR title",
+              "Validate PR title",
               // "any:continuous-integration/jenkins/pr-merge",
           ],
         },
         customBranchProtectionRule('docs-develop') {
           required_status_checks+: [
-              // "Validate PR title",
+              "Validate PR title",
           ]
         },
         customBranchProtectionRule('release-*') {
           required_status_checks+: [
-              // "Validate PR title",
+              "Validate PR title",
               // "any:continuous-integration/jenkins/pr-merge",
           ],
         },
         customBranchProtectionRule('docs-release-*') {
           required_status_checks+: [
-              // "Validate PR title",
+              "Validate PR title",
           ]
         },
       ],


### PR DESCRIPTION
Thanks to:
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5067#note_2829681
- https://github.com/eclipse-kura/.eclipsefdn/pull/11
- https://github.com/eclipse-kura/kura/pull/5397

we can now safely restore the "Validate PR title" required status check for our CI.

Tested working on the documentation branches (see https://github.com/eclipse-kura/kura/pull/5400), as you can see the Github workflow is correctly triggered even if the PR is opened by a bot.