### PR TITLE
ci: re-enable Jenkins CI required status check via custom ruleset

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -10,7 +10,7 @@ local customDevRuleset(name) =
     ],
     required_pull_request: {
         dismisses_stale_reviews: true,
-        require_last_push_approval: true,
+        requires_last_push_approval: true,
         required_approving_review_count: 1,
     },
     required_status_checks+: [
@@ -29,7 +29,7 @@ local customDocRuleset(name) =
     ],
     required_pull_request: {
         dismisses_stale_reviews: true,
-        require_last_push_approval: true,
+        requires_last_push_approval: true,
         required_approving_review_count: 1,
     },
     required_status_checks+: [

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -12,7 +12,7 @@ local customDevRuleset(name) =
         dismisses_stale_reviews: true,
         require_last_push_approval: true,
         required_approving_review_count: 1,
-    }
+    },
     required_status_checks+: [
       "Validate PR title",
       "any:continuous-integration/jenkins/pr-merge",
@@ -31,7 +31,7 @@ local customDocRuleset(name) =
         dismisses_stale_reviews: true,
         require_last_push_approval: true,
         required_approving_review_count: 1,
-    }
+    },
     required_status_checks+: [
       "Validate PR title",
     ],

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -1,10 +1,38 @@
 local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
-local customBranchProtectionRule(name) = 
-  orgs.newBranchProtectionRule(name) {
+local customDevRuleset(name) =
+  orgs.newRepoRuleset(name) {
+    bypass_actors+: [
+      "@eclipse-kura/iot-kura-project-leads"
+    ],
+    include_refs+: [
+      std.format("refs/heads/%s", name),
+    ],
     dismisses_stale_reviews: true,
     require_last_push_approval: true,
     required_approving_review_count: 1,
+    requires_status_checks: true,
+    required_status_checks+: [
+      "Validate PR title",
+      "any:continuous-integration/jenkins/pr-merge",
+    ],
+  };
+
+local customDocRuleset(name) =
+  orgs.newRepoRuleset(name) {
+    bypass_actors+: [
+      "@eclipse-kura/iot-kura-project-leads"
+    ],
+    include_refs+: [
+      std.format("refs/heads/%s", name),
+    ],
+    dismisses_stale_reviews: true,
+    require_last_push_approval: true,
+    required_approving_review_count: 1,
+    requires_status_checks: true,
+    required_status_checks+: [
+      "Validate PR title",
+    ],
   };
 
 orgs.newOrg('eclipse-kura') {
@@ -97,29 +125,11 @@ orgs.newOrg('eclipse-kura') {
           secret: "********",
         },
       ],
-      branch_protection_rules: [
-        customBranchProtectionRule('develop') {
-          required_status_checks+: [
-              "Validate PR title",
-              // "any:continuous-integration/jenkins/pr-merge",
-          ],
-        },
-        customBranchProtectionRule('docs-develop') {
-          required_status_checks+: [
-              "Validate PR title",
-          ]
-        },
-        customBranchProtectionRule('release-*') {
-          required_status_checks+: [
-              "Validate PR title",
-              // "any:continuous-integration/jenkins/pr-merge",
-          ],
-        },
-        customBranchProtectionRule('docs-release-*') {
-          required_status_checks+: [
-              "Validate PR title",
-          ]
-        },
+      rulesets: [
+        customDevRuleset('develop'),
+        customDevRuleset('release-*'),
+        customDocRuleset('docs-develop'),
+        customDocRuleset('docs-release-*')
       ],
       environments: [
         orgs.newEnvironment('github-pages') {

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -8,10 +8,11 @@ local customDevRuleset(name) =
     include_refs+: [
       std.format("refs/heads/%s", name),
     ],
-    dismisses_stale_reviews: true,
-    require_last_push_approval: true,
-    required_approving_review_count: 1,
-    requires_status_checks: true,
+    required_pull_request: {
+        dismisses_stale_reviews: true,
+        require_last_push_approval: true,
+        required_approving_review_count: 1,
+    }
     required_status_checks+: [
       "Validate PR title",
       "any:continuous-integration/jenkins/pr-merge",
@@ -26,10 +27,11 @@ local customDocRuleset(name) =
     include_refs+: [
       std.format("refs/heads/%s", name),
     ],
-    dismisses_stale_reviews: true,
-    require_last_push_approval: true,
-    required_approving_review_count: 1,
-    requires_status_checks: true,
+    required_pull_request: {
+        dismisses_stale_reviews: true,
+        require_last_push_approval: true,
+        required_approving_review_count: 1,
+    }
     required_status_checks+: [
       "Validate PR title",
     ],


### PR DESCRIPTION
As per our discussion in #8, I followed the suggestion reported [here](https://github.com/eclipse-kura/.eclipsefdn/pull/8#issuecomment-2385116434) creating custom rulesets to allow only [the project leads](https://github.com/orgs/eclipse-kura/teams/iot-kura-project-leads) to bypass the required status checks.

This allows us to restore the required status check for the Jenkins CI.

@netomi Feel free to provide further suggestions since I'm fairly new to this tool and Jsonnet.
