### PR TITLE
ci: add ruleset to kura-website "hugo_migration" branch

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -161,8 +161,13 @@ orgs.newOrg('eclipse-kura') {
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "master",
+      homepage: "https://eclipse.dev/kura/",
+      description: "Eclipse Kura™ website",
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
+      rulesets: [
+        customDocRuleset('hugo_migration'),
+      ],
       workflows+: {
         enabled: true,
       },


### PR DESCRIPTION
Requires https://github.com/eclipse-kura/kura-website/pull/31 to be merged.