### PR TITLE
feat: create new `copyright-check` repository

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -172,6 +172,13 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
         enabled: true,
       },
     },
+    orgs.newRepo('copyright-check') {
+      default_branch: "develop",
+      description: "Copyright check tool for Eclipse Kura projects",
+      workflows+: {
+        enabled: true,
+      },
+    },
   ],
 } + {
   # snippet added due to 'https://github.com/EclipseFdn/otterdog-configs/blob/main/blueprints/add-dot-github-repo.yml'

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -173,6 +173,9 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
       },
     },
     orgs.newRepo('copyright-check') {
+      allow_merge_commit: false,
+      allow_rebase_merge: false,
+      allow_squash_merge: true,
       default_branch: "develop",
       description: "Copyright check tool for Eclipse Kura™ projects",
       delete_branch_on_merge: true,

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -174,7 +174,9 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
     },
     orgs.newRepo('copyright-check') {
       default_branch: "develop",
-      description: "Copyright check tool for Eclipse Kura projects",
+      description: "Copyright check tool for Eclipse Kura™ projects",
+      delete_branch_on_merge: true,
+      web_commit_signoff_required: false,
       workflows+: {
         enabled: true,
       },


### PR DESCRIPTION
This PR creates a new repository to host our `copyright-check` tools.

We'll add the code and the necessary automation as soon as the repo is available. We'll set the branch protection rules at a later time.