### PR TITLE
fix: correct name for status check AGAIN

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -171,7 +171,7 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
       web_commit_signoff_required: false,
       rulesets: [
         customRuleset('develop', [
-          "Lint PR",
+          "call-workflow-in-public-repo/Validate PR title",
         ]),
       ],
       workflows+: {


### PR DESCRIPTION
Following https://otterdog.readthedocs.io/en/latest/reference/organization/repository/status-check/ **this** time the status check should be correct.