### PR TITLE
fix: correct name for status check AGAIN

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -171,7 +171,7 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
       web_commit_signoff_required: false,
       rulesets: [
         customRuleset('develop', [
-          "call-workflow-in-public-repo/Validate PR title",
+          "Lint PR / call-workflow-in-public-repo / Validate PR title",
         ]),
       ],
       workflows+: {

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -171,7 +171,7 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
       web_commit_signoff_required: false,
       rulesets: [
         customRuleset('develop', [
-          "Lint PR / call-workflow-in-public-repo / Validate PR title",
+          "call-workflow-in-public-repo / Validate PR title",
         ]),
       ],
       workflows+: {


### PR DESCRIPTION
@netomi I clearly need help here. Is this correct?

The status check I'm trying to enforce is the one passing in the screenshot:
![image](https://github.com/user-attachments/assets/b6ba4c39-56d1-4eb1-bb8f-a6fc6a1cc6ec)

More details here: https://github.com/eclipse-kura/copyright-check/pull/3