### PR TITLE
feat: create `metadata-generator` repository

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -181,6 +181,23 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
         enabled: true,
       },
     },
+    orgs.newRepo('metadata-generator') {
+      allow_merge_commit: false,
+      allow_rebase_merge: false,
+      allow_squash_merge: true,
+      default_branch: "develop",
+      description: "Eclipse Kura™ Metadata Generator",
+      delete_branch_on_merge: true,
+      web_commit_signoff_required: false,
+      // rulesets: [
+      //   customRuleset('develop', [
+      //     "call-workflow-in-public-repo / Validate PR title",
+      //   ]),
+      // ],
+      // workflows+: {
+      //   enabled: true,
+      // },
+    },
     orgs.newRepo('copyright-check') {
       allow_merge_commit: false,
       allow_rebase_merge: false,


### PR DESCRIPTION
Given that https://github.com/eclipse-kura/kura/pull/5563 was merged we now want to host the `metadata-generator` script under the `eclipse-kura` organization. This PR creates the repository for the project.

**Note**: rulesets will be added once the repository is created and the initial contribution is performed.