### PR TITLE
ci: enable branch protection rules for metadata-generator repo

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -188,15 +188,18 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
       default_branch: "develop",
       description: "Eclipse Kura™ Metadata Generator",
       delete_branch_on_merge: true,
+      has_wiki: false,
+      has_projects: false,
       web_commit_signoff_required: false,
-      // rulesets: [
-      //   customRuleset('develop', [
-      //     "call-workflow-in-public-repo / Validate PR title",
-      //   ]),
-      // ],
-      // workflows+: {
-      //   enabled: true,
-      // },
+      squash_merge_commit_title: "PR_TITLE",
+      rulesets: [
+        customRuleset('develop', [
+          "call-workflow-in-public-repo / Validate PR title",
+        ]),
+      ],
+      workflows+: {
+        enabled: true,
+      },
     },
     orgs.newRepo('copyright-check') {
       allow_merge_commit: false,


### PR DESCRIPTION
Enable branch protection rules for the newly created `metadata-generator` repository and add a couple of custom settings.