### PR TITLE
refactor: change main branch of kura apps to develop

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -155,7 +155,7 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
       code_scanning_default_setup_enabled: false,
       default_branch: "develop",
       description: "Applications for Eclipse Kura™ framework",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       has_wiki: false,
       web_commit_signoff_required: false,
       rulesets: [

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -153,13 +153,13 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
       allow_rebase_merge: false,
       allow_squash_merge: true,
       code_scanning_default_setup_enabled: false,
-      default_branch: "master",
+      default_branch: "develop",
       description: "Applications for Eclipse Kura™ framework",
       delete_branch_on_merge: false,
       has_wiki: false,
       web_commit_signoff_required: false,
       rulesets: [
-        customRuleset('master', [
+        customRuleset('develop', [
           "continuous-integration/jenkins/pr-merge",
         ])
       ],


### PR DESCRIPTION
Changing main branch of [Kura Apps repo](https://github.com/eclipse-kura/kura-apps) from `master` to `develop`. 