### PR TITLE
ci: add rulesets in kura-artemis

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -266,6 +266,12 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
       has_wiki: false,
       web_commit_signoff_required: false,
       squash_merge_commit_title: "PR_TITLE",
+      rulesets: [
+        customRuleset('develop', [
+          "call-workflow-in-public-repo / Validate PR title",
+          "continuous-integration/jenkins/pr-merge",
+        ])
+      ],
     },
   ],
 } + {


### PR DESCRIPTION
This PR adds the rulesets for validating the PR title in the `kura-artemis` repository. Added later since waiting for merge of PR: https://github.com/eclipse-kura/kura-artemis/pull/1