### PR TITLE
ci: branch protection rules for divergent plugins in shared libs

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -344,6 +344,9 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
       rulesets: [
         customRuleset('develop', [
           "call-workflow-in-public-repo / Validate PR title"
+        ]),
+        customRuleset('plugin/*', [
+          "call-workflow-in-public-repo / Validate PR title"
         ])
       ]
     },


### PR DESCRIPTION
Sorry, I forgot about divergent plugins in my last PR