### PR TITLE
fix: allow protected branch creation

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -2,6 +2,7 @@ local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
 local customRuleset(name, checks) =
   orgs.newRepoRuleset(name) {
+    do_not_enforce_on_create: true,
     allows_creations: true,
     bypass_actors+: [
       "@eclipse-kura/iot-kura-project-leads",

--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -2,7 +2,6 @@ local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
 local customRuleset(name, checks) =
   orgs.newRepoRuleset(name) {
-    do_not_enforce_on_create: true,
     allows_creations: true,
     bypass_actors+: [
       "@eclipse-kura/iot-kura-project-leads",
@@ -17,6 +16,7 @@ local customRuleset(name, checks) =
         required_approving_review_count: 1,
     },
     required_status_checks+: {
+      do_not_enforce_on_create: true,
       status_checks+: checks,
     },
   };


### PR DESCRIPTION
As per https://otterdog.readthedocs.io/en/latest/reference/organization/repository/ruleset/


Key | Value | Description | Notes
-- | -- | -- | --
do_not_enforce_on_create | boolean | If enabled, allow repositories and branches to be created if a check would otherwise prohibit it

This should fix the error we're currently experiencing when trying to create a branch affected by protection rules.

<img width="507" height="130" alt="image" src="https://github.com/user-attachments/assets/ef74fe93-558d-40d8-b936-9e9f9bbc57f8" />

See also:
- #66 
- #63 