### PR TITLE
ci: PR workflows always require approval from a maintainer

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -88,6 +88,9 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
     description: "",
     name: "Eclipse Kura",
     web_commit_signoff_required: false,
+    workflows+: {
+        fork_pr_approval_policy: "all_external_contributors"
+    }
   },
   teams+: [
     orgs.newTeam('merge-bypass') {


### PR DESCRIPTION
Fork PR workflows require approval from a maintainer for all external contributors