### PR TITLE
feat: enable discussions on org page

### DIFF
--- a/otterdog/eclipse-kura.jsonnet
+++ b/otterdog/eclipse-kura.jsonnet
@@ -88,6 +88,8 @@ orgs.newOrg('iot.kura', 'eclipse-kura') {
     description: "",
     name: "Eclipse Kura",
     web_commit_signoff_required: false,
+    has_discussions: true,
+    discussion_source_repository: "eclipse-kura/kura"
   },
   teams+: [
     orgs.newTeam('merge-bypass') {


### PR DESCRIPTION
While working digging in the docs I noticed this setting. It simply adds the `kura-core` repository discussion page at the home page of our org. Given that our main discussion forum is the `kura-core` repository discussions it makes sense to make it more visible.